### PR TITLE
Fixes the GDrive Download Function for EmberGBDT Weights

### DIFF
--- a/examples/prediction/predict_score_of_executable_simple_ember.py
+++ b/examples/prediction/predict_score_of_executable_simple_ember.py
@@ -1,0 +1,11 @@
+import torch
+from secmlware.zoo.ember_gbdt import EmberGBDT
+from secmlware.data.loader import load_single_exe
+
+exe_filepath = "path/to/exe/file/"
+# model_path = "/path/to/model/state/dict"
+model_path = None # will download the model from Google Drive
+
+malconv = EmberGBDT.create_model()
+x = load_single_exe(exe_filepath).to(torch.long).unsqueeze(0)
+print(malconv(x).item())

--- a/examples/prediction/predict_score_of_executable_simple_malconv.py
+++ b/examples/prediction/predict_score_of_executable_simple_malconv.py
@@ -1,0 +1,11 @@
+import torch
+from secmlware.zoo.malconv import MalConv
+from secmlware.data.loader import load_single_exe
+
+exe_filepath = "path/to/exe/file/"
+# model_path = "/path/to/model/state/dict"
+model_path = None # will download the model from Google Drive
+
+malconv = MalConv.create_model()
+x = load_single_exe(exe_filepath).to(torch.long).unsqueeze(0)
+print(malconv(x).item())

--- a/src/secmlware/zoo/ember_gbdt.py
+++ b/src/secmlware/zoo/ember_gbdt.py
@@ -13,9 +13,10 @@ from secmlware.zoo.model import Model
 
 
 class EmberGBDT(Model):
-    # TODO add gdrive ID
     def __init__(self, model_path: str = ""):
-        super().__init__("ember_gbdt", "1MGR7l5c3XSH2dTj2oeefBlKig0bvH2_Z")
+        super().__init__(
+            name="ember_gbdt", gdrive_id="1MGR7l5c3XSH2dTj2oeefBlKig0bvH2_Z"
+        )
         self.tree_model = None
         self.load_pretrained_model(model_path=model_path)
 


### PR DESCRIPTION
Ember GBDT weights download link expressed different behavior from Drive -- it required a UUID token to bypass Virus Scan interface:

![image](https://github.com/user-attachments/assets/e2751d7f-ed3d-41a8-8d01-e9884972a9e4)

Original code didn't expected this behavior (expects token in Cookies), but here there is no token in cookies, only UUID in HTML:

![image](https://github.com/user-attachments/assets/9b8a2496-881c-458f-aea2-dcd50d6d7af0)

Code updated to work for both scenarios.
