### PR TITLE
removed repeated _fetch_pretrained_model() in EmberGBDT model class

### DIFF
--- a/src/maltorch/zoo/ember_gbdt.py
+++ b/src/maltorch/zoo/ember_gbdt.py
@@ -17,7 +17,6 @@ class EmberGBDT(Model):
         super().__init__(
             name="ember_gbdt", gdrive_id="1RWvr3yD8M90EXcTozK2TwW2JEExQ9qDW"
         )
-        self._fetch_pretrained_model()
         self.tree_model = None
         if model_path is None:
             model_path = self.model_path


### PR DESCRIPTION
Removed repeated instructions for downloading the pretrained model from Google Drive. This caused the model to be fetched from the drive, even when a model path was specified in the constructor. 