### PR TITLE
added method _conform_input_size() for Embedding models.

### DIFF
--- a/src/maltorch/zoo/avaststyleconv.py
+++ b/src/maltorch/zoo/avaststyleconv.py
@@ -14,6 +14,7 @@ from maltorch.zoo.model import EmbeddingModel
 class AvastStyleConv(EmbeddingModel):
     def __init__(self,
                  embedding_size: int = 8,
+                 min_len: int = 10244,
                  max_len: int = 512000,
                  threshold: float = 0.5,
                  padding_idx: int = 256,
@@ -21,7 +22,7 @@ class AvastStyleConv(EmbeddingModel):
                  window_size: int = 32,
                  stride: int = 4):
         super(AvastStyleConv, self).__init__(
-            name="AvastStyleConv", gdrive_id=None
+            name="AvastStyleConv", gdrive_id=None, min_len=min_len, max_len=max_len
         )
         # "14wSZQ-Drns9G8CEqvfbAZjmMVt_ToUbp"
         self.max_len = max_len

--- a/src/maltorch/zoo/bbdnn.py
+++ b/src/maltorch/zoo/bbdnn.py
@@ -14,11 +14,12 @@ class BBDnn(EmbeddingModel):
     def __init__(
             self,
             embedding_size: int = 10,
+            min_len: int = 4096,
             max_len: int = 102400,
             threshold: float = 0.5,
             padding_idx: int = 256,
     ):
-        super(BBDnn, self).__init__(name="bbdnn", gdrive_id="1c_9lVHT9zYpBCwQfnUW6ZbCF6SaVabRZ")
+        super(BBDnn, self).__init__(name="bbdnn", gdrive_id="1c_9lVHT9zYpBCwQfnUW6ZbCF6SaVabRZ", min_len=min_len, max_len=max_len)
         self.max_len = max_len
         self.threshold = threshold
         self.embedding_1 = torch.nn.Embedding(
@@ -134,11 +135,6 @@ class BBDnn(EmbeddingModel):
         emb_x = self.embedding_1(x)
         emb_x = emb_x.transpose(1, 2)
         return emb_x
-
-    def forward(self, x):
-        x = self.embed(x)  # Shape: (batch_size, seq_len, embedding_size)
-        x = self._forward_embed_x(x)
-        return x
 
     def embedding_matrix(self):
         return self.embedding_1.weight

--- a/src/maltorch/zoo/malconv.py
+++ b/src/maltorch/zoo/malconv.py
@@ -23,7 +23,7 @@ class MalConv(EmbeddingModel):
                  kernel_size=512,
                  stride=512):
         super(MalConv, self).__init__(
-            name="MalConv", gdrive_id="1Hg8I7Jx13LmnSPBjsPGr8bvmmS874Y9N"
+            name="MalConv", gdrive_id="1Hg8I7Jx13LmnSPBjsPGr8bvmmS874Y9N", max_len=max_len
         )
         self.embedding_1 = nn.Embedding(
             num_embeddings=257, embedding_dim=embedding_size, padding_idx=padding_idx

--- a/src/maltorch/zoo/model.py
+++ b/src/maltorch/zoo/model.py
@@ -7,6 +7,8 @@ from secmlt.models.data_processing.data_processing import DataProcessing
 from secmlt.models.pytorch.base_pytorch_nn import BasePytorchClassifier
 from maltorch.utils.config import Config
 from maltorch.utils.utils import download_gdrive
+import torch.nn.functional as F
+
 
 
 class Model(torch.nn.Module, ABC):
@@ -124,10 +126,12 @@ class EmbeddingModel(PytorchModel, ABC):
         return net
 
     def __init__(
-        self, name: str, gdrive_id: Optional[str], input_embedding: bool = False
+        self, name: str, gdrive_id: Optional[str], input_embedding: bool = False, min_len : Optional[int] = None, max_len: Optional[int] = None
     ):
         super().__init__(name, gdrive_id)
         self.input_embedding = input_embedding
+        self.min_len = min_len
+        self.max_len = max_len
 
     @abstractmethod
     def embed(self, x):
@@ -145,6 +149,21 @@ class EmbeddingModel(PytorchModel, ABC):
     def _forward_embed_x(self, x):
         pass
 
+    def _conform_input_size(self, x: torch.Tensor, padding: int = 256) -> torch.Tensor:
+
+        if self.max_len is None and self.min_len is None:
+            return x
+
+        batch_size, current_size = x.shape
+
+        if self.min_len is not None:
+            padding_needed = max(0, self.min_len - current_size)
+            x = F.pad(x, (0, padding_needed), "constant", padding)
+
+        x = x[:, :self.max_len]
+
+        return x
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Forward pass.
@@ -158,6 +177,7 @@ class EmbeddingModel(PytorchModel, ABC):
         torch.Tensor
             the result of the forward pass
         """
+        x = self._conform_input_size(x)
         x = self.embed(x)
         output = self._forward_embed_x(x)
         return output

--- a/src/maltorch/zoo/ngramconv.py
+++ b/src/maltorch/zoo/ngramconv.py
@@ -29,7 +29,7 @@ class NGramConv(EmbeddingModel):
                  threshold: float = 0.5,
                  padding_idx: int = 256):
         super(NGramConv, self).__init__(
-            name="NGramConv", gdrive_id=None
+            name="NGramConv", gdrive_id=None, max_len=max_len
         )
         self.embedding_1 = nn.Embedding(
             num_embeddings=257, embedding_dim=embedding_size, padding_idx=padding_idx


### PR DESCRIPTION
With this change, embedding models trim or pad input sequences before passing them to the embedding layer.